### PR TITLE
🏓 [src] improvements for copilot review issues that were in #2, fixes #3

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ Key functions and their roles:
 - `pr_list_args()` -- Builds a shared `gh pr list` args array from globals (used by both `cmd_list` and `select_pr`)
 - `select_pr()` -- Interactive numbered menu; prints PR number to stdout for capture by caller
 - `review_pr()` -- Infinite loop presenting a numbered action menu for a single PR
-- `approve_pr()` / `merge_pr()` / `pull_pr()` -- Individual action steps called by the review loop
+- `approve_pr()` / `merge_pr()` / `pull_pr()` -- Individual action steps called by the review loop. `pull_pr()` checks out and pulls the base branch to sync it locally.
 
 ## Development Commands
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ gh amp status
 gh amp status 42
 
 # Show status for a PR in a different repo
-gh amp status 42 -R fini-net/gh-amp
+gh amp -R fini-net/gh-amp status 42
 ```
 
 ### `gh amp review`
@@ -71,15 +71,14 @@ gh amp review --author @me
 gh amp review --merge-strategy rebase
 ```
 
-The review command presents a menu with options to:
+The review command shows the PR diff, then presents a menu with options to:
 
 1. View CI status
-2. View diff
-3. Approve PR
-4. Merge PR (configurable strategy: squash, merge, or rebase)
-5. Pull branch locally
-6. Approve + Merge + Pull (full workflow)
-7. Open in browser
+2. Approve PR
+3. Merge PR (configurable strategy: squash, merge, or rebase)
+4. Sync base branch (checkout and pull the base branch)
+5. Approve + Merge + Sync (full workflow)
+6. Open in browser
 
 ## Flags
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ gh amp status 42
 
 # Show status for a PR in a different repo
 gh amp -R fini-net/gh-amp status 42
+
+# Show status with a different order of arguments
+gh amp status 42 -R fini-net/gh-amp
 ```
 
 ### `gh amp review`

--- a/gh-amp
+++ b/gh-amp
@@ -12,6 +12,19 @@ CYAN="\033[36m"
 DIM="\033[2m"
 RESET="\033[0m"
 
+sanitize() {
+    printf '%s' "$1" | sed 's/\x1b\[[0-9;]*m//g'
+}
+
+check_dependencies() {
+    for cmd in gh jq; do
+        if ! command -v "$cmd" &>/dev/null; then
+            echo "Error: Required command '$cmd' not found. Please install it first." >&2
+            exit 1
+        fi
+    done
+}
+
 REPO=""
 STATE="open"
 LIMIT=30
@@ -174,10 +187,10 @@ select_pr() {
     while IFS= read -r line; do
         local num title author branch base review mergeable
         num="$(echo "$line" | jq -r '.number')"
-        title="$(echo "$line" | jq -r '.title')"
-        author="$(echo "$line" | jq -r '.author.login')"
-        branch="$(echo "$line" | jq -r '.headRefName')"
-        base="$(echo "$line" | jq -r '.baseRefName')"
+        title="$(sanitize "$(echo "$line" | jq -r '.title')")"
+        author="$(sanitize "$(echo "$line" | jq -r '.author.login')")"
+        branch="$(sanitize "$(echo "$line" | jq -r '.headRefName')")"
+        base="$(sanitize "$(echo "$line" | jq -r '.baseRefName')")"
         review="$(echo "$line" | jq -r '.reviewDecision')"
         mergeable="$(echo "$line" | jq -r '.mergeable')"
 
@@ -231,16 +244,16 @@ review_pr() {
         echo -e "${BOLD}  PR #${pr_number}${RESET}"
 
         local pr_info
-        pr_info="$(gh pr view "$pr_number" ${repo_args[@]+${repo_args[@]+"${repo_args[@]}"}} --json title,author,headRefName,baseRefName,state,reviewDecision,mergeable,url 2>/dev/null)" || {
+        pr_info="$(gh pr view "$pr_number" "${repo_args[@]}" --json title,author,headRefName,baseRefName,state,reviewDecision,mergeable,url 2>/dev/null)" || {
             log_error "Could not fetch PR #$pr_number"
             return 1
         }
 
         local title author branch base state review mergeable url
-        title="$(echo "$pr_info" | jq -r '.title')"
-        author="$(echo "$pr_info" | jq -r '.author.login')"
-        branch="$(echo "$pr_info" | jq -r '.headRefName')"
-        base="$(echo "$pr_info" | jq -r '.baseRefName')"
+        title="$(sanitize "$(echo "$pr_info" | jq -r '.title')")"
+        author="$(sanitize "$(echo "$pr_info" | jq -r '.author.login')")"
+        branch="$(sanitize "$(echo "$pr_info" | jq -r '.headRefName')")"
+        base="$(sanitize "$(echo "$pr_info" | jq -r '.baseRefName')")"
         state="$(echo "$pr_info" | jq -r '.state')"
         review="$(echo "$pr_info" | jq -r '.reviewDecision')"
         mergeable="$(echo "$pr_info" | jq -r '.mergeable')"
@@ -260,8 +273,8 @@ review_pr() {
         echo -e "  ${BOLD}1)${RESET}  View CI status"
         echo -e "  ${BOLD}2)${RESET}  Approve PR"
         echo -e "  ${BOLD}3)${RESET}  Merge PR (${MERGE_STRATEGY})"
-        echo -e "  ${BOLD}4)${RESET}  Pull branch locally"
-        echo -e "  ${BOLD}5)${RESET}  Approve + Merge + Pull (full workflow)"
+        echo -e "  ${BOLD}4)${RESET}  Sync base branch (${base})"
+        echo -e "  ${BOLD}5)${RESET}  Approve + Merge + Sync (full workflow)"
         echo -e "  ${BOLD}6)${RESET}  Open in browser"
         echo -e "  ${BOLD}0)${RESET}  Back / Exit"
         echo ""
@@ -380,6 +393,14 @@ pull_pr() {
     fi
 }
 
+validate_flag_value() {
+    if [[ $# -lt 2 || -z "${2-}" ]]; then
+        echo "Error: $1 requires a value." >&2
+        usage
+        exit 1
+    fi
+}
+
 main() {
     local command=""
     local remaining_args=()
@@ -389,7 +410,6 @@ main() {
             list|status|review)
                 command="$1"
                 shift
-                break
                 ;;
             help|--help|-h)
                 usage
@@ -400,43 +420,50 @@ main() {
                 exit 0
                 ;;
             -R|--repo)
+                validate_flag_value "$@"
                 REPO="$2"
                 shift 2
                 ;;
             -A|--author)
+                validate_flag_value "$@"
                 AUTHOR="$2"
                 shift 2
                 ;;
             -l|--label)
+                validate_flag_value "$@"
                 LABEL="$2"
                 shift 2
                 ;;
             -s|--state)
+                validate_flag_value "$@"
                 STATE="$2"
                 shift 2
                 ;;
             -L|--limit)
+                validate_flag_value "$@"
                 LIMIT="$2"
                 shift 2
                 ;;
             -S|--search)
+                validate_flag_value "$@"
                 SEARCH="$2"
                 shift 2
                 ;;
             --merge-strategy)
+                validate_flag_value "$@"
                 MERGE_STRATEGY="$2"
                 shift 2
                 ;;
             *)
+                if [[ -z "$command" ]]; then
+                    echo "Error: Unknown argument: $1" >&2
+                    usage
+                    exit 1
+                fi
                 remaining_args+=("$1")
                 shift
                 ;;
         esac
-    done
-
-    while [[ $# -gt 0 ]]; do
-        remaining_args+=("$1")
-        shift
     done
 
     case "$command" in
@@ -456,4 +483,5 @@ main() {
     esac
 }
 
+check_dependencies
 main "$@"

--- a/gh-amp
+++ b/gh-amp
@@ -244,7 +244,7 @@ review_pr() {
         echo -e "${BOLD}  PR #${pr_number}${RESET}"
 
         local pr_info
-        pr_info="$(gh pr view "$pr_number" "${repo_args[@]}" --json title,author,headRefName,baseRefName,state,reviewDecision,mergeable,url 2>/dev/null)" || {
+        pr_info="$(gh pr view "$pr_number" ${repo_args[@]+"${repo_args[@]}"} --json title,author,headRefName,baseRefName,state,reviewDecision,mergeable,url 2>/dev/null)" || {
             log_error "Could not fetch PR #$pr_number"
             return 1
         }

--- a/gh-amp
+++ b/gh-amp
@@ -13,7 +13,7 @@ DIM="\033[2m"
 RESET="\033[0m"
 
 sanitize() {
-    printf '%s' "$1" | sed 's/\x1b\[[0-9;]*m//g'
+    printf '%s' "$1" | sed $'s/\033\\[[0-9;]*m//g'
 }
 
 check_dependencies() {

--- a/gh-amp
+++ b/gh-amp
@@ -468,12 +468,15 @@ main() {
 
     case "$command" in
         list)
+            check_dependencies
             cmd_list
             ;;
         status)
+            check_dependencies
             cmd_status "${remaining_args[0]:-}"
             ;;
         review)
+            check_dependencies
             cmd_review
             ;;
         "")
@@ -483,5 +486,4 @@ main() {
     esac
 }
 
-check_dependencies
 main "$@"

--- a/gh-amp
+++ b/gh-amp
@@ -408,6 +408,11 @@ main() {
     while [[ $# -gt 0 ]]; do
         case "$1" in
             list|status|review)
+                if [[ -n "$command" ]]; then
+                    echo "Error: Multiple subcommands given: $command and $1" >&2
+                    usage
+                    exit 1
+                fi
                 command="$1"
                 shift
                 ;;

--- a/gh-amp
+++ b/gh-amp
@@ -3,14 +3,14 @@ set -euo pipefail
 
 VERSION="0.1.0"
 
-BOLD="\033[1m"
-GREEN="\033[32m"
-YELLOW="\033[33m"
-RED="\033[31m"
-BLUE="\033[34m"
-CYAN="\033[36m"
-DIM="\033[2m"
-RESET="\033[0m"
+BOLD=$'\033[1m'
+GREEN=$'\033[32m'
+YELLOW=$'\033[33m'
+RED=$'\033[31m'
+BLUE=$'\033[34m'
+CYAN=$'\033[36m'
+DIM=$'\033[2m'
+RESET=$'\033[0m'
 
 sanitize() {
     printf '%s' "$1" | sed $'s/\033\\[[0-9;]*m//g'

--- a/gh-amp
+++ b/gh-amp
@@ -460,6 +460,11 @@ main() {
                     usage
                     exit 1
                 fi
+                if [[ "$1" == -* ]]; then
+                    echo "Error: Unknown flag: $1" >&2
+                    usage
+                    exit 1
+                fi
                 remaining_args+=("$1")
                 shift
                 ;;

--- a/justfile
+++ b/justfile
@@ -24,7 +24,7 @@ install:
 # uninstall the local extension
 [group('Development')]
 uninstall:
-	gh extension remove gh-amp
+	-gh extension remove gh-amp
 
 # run amp locally (without installing)
 [group('Development')]
@@ -42,13 +42,13 @@ build: shellcheck-amp uninstall && install
 	# all in header
 
 # test list
-[group('Development')]
 [working-directory: '../gh-observer/']
+[group('Development')]
 test_list:
 	gh amp list
 
 # test review
-[group('Development')]
 [working-directory: '../gh-observer/']
+[group('Development')]
 test_review:
 	gh amp review


### PR DESCRIPTION
<!-- PR_BODY_DONE_START -->
## Done

- 🏓 [src] improvements for copilot review issues that were in #2, fixes #3
- fixes for claude code review
- let --help/--version work even if dependencies are missing that are needed for list/status/review subcommands
- fix escapes so bold headings work in the terminal
- show both orders of arguments in README
- unknown arguments at the end will also produce a usage() message
- fix portability regression noted by claude code review
- guard against multiple subcommands on the same command line

<!-- PR_BODY_DONE_END -->

## Meta

(Automated in `.just/gh-process.just`.)





